### PR TITLE
WC_Template_Loader::unsupported_theme_title_filter() - sidabar.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -59,7 +59,7 @@
 					?>
 							<form class="form-inline search-form my-2 my-lg-0" role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 								<div class="input-group">
-									<input type="text" name="s" class="form-control" placeholder="<?php _e( 'Search', 'my-theme' ); ?>" title="<?php esc_attr_e( 'Search', 'my-theme' ); ?>" />
+									<input type="text" name="s" class="form-control" placeholder="<?php esc_attr_e( 'Search', 'my-theme' ); ?>" title="<?php esc_attr_e( 'Search', 'my-theme' ); ?>" />
 									<div class="input-group-append">
 										<button type="submit" name="submit" class="btn btn-outline-secondary"><?php esc_html_e( 'Search', 'my-theme' ); ?></button>
 									</div>

--- a/searchform.php
+++ b/searchform.php
@@ -8,9 +8,9 @@
 	<div class="row">
 		<div class="col-md-6">
 			<div class="input-group">
-				<input type="text" name="s" class="form-control" placeholder="<?php _e( 'Search', 'my-theme' ); ?>" />
+				<input type="text" name="s" class="form-control" placeholder="<?php esc_attr_e( 'Search', 'my-theme' ); ?>" />
 				<div class="input-group-append">
-					<button type="submit" class="btn btn-secondary" name="submit"><?php _e( 'Search', 'my-theme' ); ?></button>
+					<button type="submit" class="btn btn-secondary" name="submit"><?php esc_html_e( 'Search', 'my-theme' ); ?></button>
 				</div><!-- /.input-group-append -->
 			</div><!-- /.input-group -->
 		</div><!-- /.col -->


### PR DESCRIPTION
Pages that have the sidebar enabled and that is running Woocommerce give the following error: WC_Template_Loader::unsupported_theme_title_filter().

After some investigation, I found that the issue lies in the sidebar.php file.