### PR TITLE
fixed sidebar WC_Template_Loader::unsupported_theme_title_filter() error.

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -43,7 +43,7 @@ if ( is_active_sidebar( 'primary_widget_area' ) || is_archive() || is_single() )
 									endif;
 									$month_check = $month;
 
-								$output .= '<h4><a href="' . esc_url( get_the_permalink() ) . '" title="' . sprintf( esc_attr__( 'Permalink to %s', 'my-theme' ), the_title_attribute( 'echo=0' ) ) . '" rel="bookmark">' . apply_filters( 'the_title', get_the_title() ) . '</a></h4>';
+								$output .= '<h4><a href="' . esc_url( get_the_permalink() ) . '" title="' . sprintf( esc_attr__( 'Permalink to %s', 'my-theme' ), the_title_attribute( 'echo=0' ) ) . '" rel="bookmark">' . apply_filters( 'the_title', get_the_title(), get_the_id() ) . '</a></h4>';
 								$output .= '</li>';
 							endwhile;
 						endif;


### PR DESCRIPTION
The following error appeared in the sidebar when running this theme with Woocommerce. After some investigation, I came across this documentation: https://developer.wordpress.org/reference/hooks/the_title/

In the existing code, the second parameter referencing the ID was missing. I have added the ID parameter by calling the get_the_id() function. 

I thought I'd try and help since I fixed it on my side, instead of creating an issue. 

Thanks for all the great work on the theme.

Cheers